### PR TITLE
fix: use `array.array.tobytes()`

### DIFF
--- a/mobi/mobi_dict.py
+++ b/mobi/mobi_dict.py
@@ -422,4 +422,4 @@ class dictSupport:
             else:
                 logger.debug("Error: Inflection rule mode %x is not implemented" % abyte)
                 return None
-        return utf8_str(byteArray.tostring())
+        return utf8_str(byteArray.tobytes())


### PR DESCRIPTION
`tostring()` was an alias of `tobytes()` since Python 2.7 & 3.2, and was removed in Python 3.9 (https://docs.python.org/3.9/whatsnew/changelog.html#id224).